### PR TITLE
Add support for Linux

### DIFF
--- a/mixxx_bisect/__init__.py
+++ b/mixxx_bisect/__init__.py
@@ -11,6 +11,7 @@ from mixxx_bisect.repository.mixxx_org import MixxxOrgSnapshotRepository
 
 from mixxx_bisect.options import Options
 from mixxx_bisect.runner import SnapshotRunner
+from mixxx_bisect.runner.linux import LinuxSnapshotRunner
 from mixxx_bisect.runner.macos import MacOSSnapshotRunner
 from mixxx_bisect.runner.windows import WindowsSnapshotRunner
 from mixxx_bisect.utils.git import clone_mixxx, commits_in_order, describe_commit, parse_commit, sort_commits
@@ -24,6 +25,7 @@ DEFAULT_ROOT = Path.home() / '.local' / 'state' / 'mixxx-bisect'
 SNAPSHOT_RUNNERS: dict[str, type[SnapshotRunner]] = {
     'Windows': WindowsSnapshotRunner,
     'Darwin': MacOSSnapshotRunner,
+    'Linux': LinuxSnapshotRunner,
 }
 
 SNAPSHOT_REPOSITORIES: dict[str, type[SnapshotRepository]] = {

--- a/mixxx_bisect/__init__.py
+++ b/mixxx_bisect/__init__.py
@@ -41,7 +41,7 @@ def main():
     parser = argparse.ArgumentParser(description='Finds Mixxx regressions using binary search')
     parser.add_argument('--repository', default='m1xxx' if os == 'Linux' else 'mixxx-org', choices=sorted(SNAPSHOT_REPOSITORIES.keys()), help=f'The snapshot repository to use.')
     parser.add_argument('--branch', default='main', help=f'The branch to search for snapshots on, if supported by the repository.')
-    parser.add_argument('--root', type=Path, default=DEFAULT_ROOT, help='The root directory where all application-specific state (i.e. the mixxx repo, downloads, mounted snapshots etc.) will be stored.')
+    parser.add_argument('--root', type=Path, default=DEFAULT_ROOT, help='The root directory where all application-specific state (i.e. the mixxx repo, downloads, installed snapshots etc.) will be stored.')
     parser.add_argument('--dump-snapshots', action='store_true', help='Dumps the fetched snapshots.')
     parser.add_argument('--verbose', action='store_true', help='Enables verbose output.')
     parser.add_argument('--arch', default=platform.machine(), help="The architecture to query for. Defaults to `platform.machine()`, requires the repository to provide corresponding binaries and is primarily useful for machines capable of running multiple architectures, e.g. via Rosetta or QEMU.")
@@ -70,7 +70,7 @@ def main():
             arch=args.arch,
             root_dir=args.root,
             mixxx_dir=args.root / 'mixxx.git',
-            mount_dir=args.root / 'mnt',
+            installs_dir=args.root / 'installs',
             log_dir=args.root / 'log',
             downloads_dir=args.root / 'downloads',
         )
@@ -82,7 +82,7 @@ def main():
         clone_mixxx(opts)
 
         # Create auxiliary directories
-        for dir in [opts.downloads_dir, opts.mount_dir, opts.log_dir]:
+        for dir in [opts.downloads_dir, opts.installs_dir, opts.log_dir]:
             dir.mkdir(parents=True, exist_ok=True)
 
         # Set up platform-specific snapshot runner

--- a/mixxx_bisect/__init__.py
+++ b/mixxx_bisect/__init__.py
@@ -91,7 +91,7 @@ def main():
         # Fetch snapshots and match them up with Git commits
         repository = SnapshotRepository(
             branch=args.branch,
-            suffix=runner.download_path.suffix,
+            suffix=runner.suffix,
             opts=opts
         )
 

--- a/mixxx_bisect/__init__.py
+++ b/mixxx_bisect/__init__.py
@@ -38,11 +38,11 @@ def main():
 
     parser = argparse.ArgumentParser(description='Finds Mixxx regressions using binary search')
     parser.add_argument('--repository', default='m1xxx' if os == 'Linux' else 'mixxx-org', choices=sorted(SNAPSHOT_REPOSITORIES.keys()), help=f'The snapshot repository to use.')
-    parser.add_argument('--branch', default='main', help=f'The branch to search for snapshots on, if supported by the hoster.')
+    parser.add_argument('--branch', default='main', help=f'The branch to search for snapshots on, if supported by the repository.')
     parser.add_argument('--root', type=Path, default=DEFAULT_ROOT, help='The root directory where all application-specific state (i.e. the mixxx repo, downloads, mounted snapshots etc.) will be stored.')
     parser.add_argument('--dump-snapshots', action='store_true', help='Dumps the fetched snapshots.')
     parser.add_argument('--verbose', action='store_true', help='Enables verbose output.')
-    parser.add_argument('--arch', default=platform.machine(), help="The architecture to query for. Defaults to `platform.machine()`, requires the hoster to provide corresponding binaries and is primarily useful for machines capable of running multiple architectures, e.g. via Rosetta or QEMU.")
+    parser.add_argument('--arch', default=platform.machine(), help="The architecture to query for. Defaults to `platform.machine()`, requires the repository to provide corresponding binaries and is primarily useful for machines capable of running multiple architectures, e.g. via Rosetta or QEMU.")
     parser.add_argument('-v', '--version', action='store_true', help='Outputs the version.')
     parser.add_argument('-q', '--quiet', action='store_true', help='Suppress output from subprocesses.')
     parser.add_argument('-g', '--good', help='The lower bound of the commit range (a good commit)')
@@ -87,13 +87,13 @@ def main():
         runner = SnapshotRunner(opts)
 
         # Fetch snapshots and match them up with Git commits
-        hoster = SnapshotRepository(
+        repository = SnapshotRepository(
             branch=args.branch,
             suffix=runner.download_path.suffix,
             opts=opts
         )
 
-        snapshots = hoster.fetch_snapshots()
+        snapshots = repository.fetch_snapshots()
         if args.dump_snapshots:
             print(json.dumps(snapshots, indent=2))
 

--- a/mixxx_bisect/__init__.py
+++ b/mixxx_bisect/__init__.py
@@ -34,8 +34,10 @@ SNAPSHOT_REPOSITORIES: dict[str, type[SnapshotRepository]] = {
 # Main
 
 def main():
+    os = platform.system()
+
     parser = argparse.ArgumentParser(description='Finds Mixxx regressions using binary search')
-    parser.add_argument('--repository', default='mixxx-org', choices=sorted(SNAPSHOT_REPOSITORIES.keys()), help=f'The snapshot repository to use.')
+    parser.add_argument('--repository', default='m1xxx' if os == 'Linux' else 'mixxx-org', choices=sorted(SNAPSHOT_REPOSITORIES.keys()), help=f'The snapshot repository to use.')
     parser.add_argument('--branch', default='main', help=f'The branch to search for snapshots on, if supported by the hoster.')
     parser.add_argument('--root', type=Path, default=DEFAULT_ROOT, help='The root directory where all application-specific state (i.e. the mixxx repo, downloads, mounted snapshots etc.) will be stored.')
     parser.add_argument('--dump-snapshots', action='store_true', help='Dumps the fetched snapshots.')
@@ -53,8 +55,6 @@ def main():
         return
 
     try:
-        os = platform.system()
-
         if os not in SNAPSHOT_RUNNERS.keys():
             raise UnsupportedOSError(f"Unsupported OS: {os} has no snapshot runner (supported are {', '.join(SNAPSHOT_RUNNERS.keys())})")
 

--- a/mixxx_bisect/__init__.py
+++ b/mixxx_bisect/__init__.py
@@ -64,6 +64,7 @@ def main():
         opts = Options(
             quiet=args.quiet,
             verbose=args.verbose,
+            os=os,
             arch=args.arch,
             root_dir=args.root,
             mixxx_dir=args.root / 'mixxx.git',

--- a/mixxx_bisect/options.py
+++ b/mixxx_bisect/options.py
@@ -9,6 +9,6 @@ class Options:
     arch: str
     root_dir: Path
     mixxx_dir: Path
-    mount_dir: Path
+    installs_dir: Path
     log_dir: Path
     downloads_dir: Path

--- a/mixxx_bisect/options.py
+++ b/mixxx_bisect/options.py
@@ -5,6 +5,7 @@ from pathlib import Path
 class Options:
     quiet: bool
     verbose: bool
+    os: str
     arch: str
     root_dir: Path
     mixxx_dir: Path

--- a/mixxx_bisect/repository/m1xxx.py
+++ b/mixxx_bisect/repository/m1xxx.py
@@ -1,5 +1,5 @@
 from typing import Optional, cast
-from mixxx_bisect.error import UnsupportedArchError
+from mixxx_bisect.error import UnsupportedArchError, UnsupportedOSError
 
 from mixxx_bisect.repository import SnapshotRepository
 from mixxx_bisect.options import Options
@@ -25,14 +25,22 @@ class M1xxxSnapshotRepository(SnapshotRepository):
         if arch is None:
             raise UnsupportedArchError(f'The architecture {opts.arch} is not supported by the m1xxx hoster.')
 
+        os = {
+            'Darwin': 'osx',
+            'Linux': 'linux',
+        }.get(opts.os)
+
+        if os is None:
+            raise UnsupportedOSError(f'The os {opts.os} is not supported by the m1xxx repository.')
+        
+        # TODO: Should we use the 'debugasserts' variant? Perhaps as an optional flag?
+        base_triplet_pattern = re.escape(arch) + r'-' + re.escape(os) + r'(?:-min\d+)?(?:-release)?'
+
         self.snapshot_name_patterns = [
-            # Newest pattern, e.g. mixxx-2.5.0.c46027.r2c2e706b44-arm64-osx-min1100-release
-            # TODO: Should we use the 'debugasserts' variant? Perhaps as an optional flag?
-            re.compile(r'^mixxx-[\d\.]+\.c\d+\.r(\w+)-' + re.escape(arch) + r'-osx-min\d+-release$'),
-            # Newer pattern, e.g. mixxx-2.5.0.c45818.r30bca40dad-arm64-osx-min1100
-            re.compile(r'^mixxx-[\d\.]+\.c\d+\.r(\w+)-' + re.escape(arch) + r'-osx-min\d+$'),
+            # Newer pattern, e.g. mixxx-2.5.0.c45818.r30bca40dad-arm64-osx-min1100-release
+            re.compile(r'^mixxx-[\d\.]+\.c\d+\.r(\w+)-' + base_triplet_pattern + r'$'),
             # New pattern, e.g. mixxx-arm64-osx-min1100-2.5.0.c45818.r30bca40dad
-            re.compile(r'^mixxx-' + re.escape(arch) + r'-osx-min\d+-[\d\.]+\.c\d+\.r(\w+)$'),
+            re.compile(r'^mixxx-' + base_triplet_pattern + r'-[\d\.]+\.c\d+\.r(\w+)$'),
             # Old pattern, e.g. mixxx-2.5.0.c45816.r7c1bb1b997
             *([re.compile(r'^mixxx-[\d\.]+\.c\d+\.r(\w+)$')] if arch == 'arm64' else []),
         ]

--- a/mixxx_bisect/repository/m1xxx.py
+++ b/mixxx_bisect/repository/m1xxx.py
@@ -23,7 +23,7 @@ class M1xxxSnapshotRepository(SnapshotRepository):
         }.get(opts.arch)
 
         if arch is None:
-            raise UnsupportedArchError(f'The architecture {opts.arch} is not supported by the m1xxx hoster.')
+            raise UnsupportedArchError(f'The architecture {opts.arch} is not supported by the m1xxx repository.')
 
         os = {
             'Darwin': 'osx',

--- a/mixxx_bisect/repository/mixxx_org.py
+++ b/mixxx_bisect/repository/mixxx_org.py
@@ -25,7 +25,7 @@ class MixxxOrgSnapshotRepository(SnapshotRepository):
         }.get(opts.arch)
 
         if arch is None:
-            raise UnsupportedArchError(f'The architecture {opts.arch} is not supported by the mixxx.org hoster.')
+            raise UnsupportedArchError(f'The architecture {opts.arch} is not supported by the mixxx.org repository.')
 
         self.snapshot_name_patterns = [
             # New pattern, e.g. mixxx-2.4-alpha-6370-g44f29763ed-macosintel

--- a/mixxx_bisect/runner/__init__.py
+++ b/mixxx_bisect/runner/__init__.py
@@ -10,6 +10,11 @@ class SnapshotRunner(Protocol):
         pass
 
     @property
+    def suffix(self) -> str:
+        '''The file extension for the downloaded artifact.'''
+        raise NotImplementedError()
+
+    @property
     def download_path(self) -> Path:
         '''The path to download to.'''
         raise NotImplementedError()

--- a/mixxx_bisect/runner/linux.py
+++ b/mixxx_bisect/runner/linux.py
@@ -8,7 +8,6 @@ import shutil
 
 class LinuxSnapshotRunner(SnapshotRunner):
     def __init__(self, opts: Options):
-        self.mount_dir = opts.mount_dir
         self.opts = opts
     
     @property
@@ -21,18 +20,18 @@ class LinuxSnapshotRunner(SnapshotRunner):
 
     def setup_snapshot(self):
         print('Extracting snapshot...')
-        shutil.unpack_archive(self.download_path, self.mount_dir)
+        shutil.unpack_archive(self.download_path, self.opts.installs_dir)
 
     def run_snapshot(self):
         print('Running snapshot...')
-        child_dirs = list(self.mount_dir.iterdir())
+        child_dirs = list(self.opts.installs_dir.iterdir())
         assert len(child_dirs) == 1, 'Mixxx should be extracted to exactly one folder'
         mixxx_dir = child_dirs[0]
         run([str(mixxx_dir / 'bin' / 'mixxx')], opts=self.opts)
     
     def cleanup_snapshot(self):
         print('Cleaning up snapshot...')
-        for path in self.opts.mount_dir.iterdir():
+        for path in self.opts.installs_dir.iterdir():
             if path.is_file():
                 path.unlink()
             else:

--- a/mixxx_bisect/runner/linux.py
+++ b/mixxx_bisect/runner/linux.py
@@ -13,8 +13,12 @@ class LinuxSnapshotRunner(SnapshotRunner):
         self.opts = opts
     
     @property
+    def suffix(self) -> str:
+        return '.tar.gz'
+
+    @property
     def download_path(self) -> Path:
-        return self.opts.downloads_dir / 'mixxx-current.tar.gz'
+        return self.opts.downloads_dir / f'mixxx-current{self.suffix}'
 
     def setup_snapshot(self):
         print('Extracting snapshot...')

--- a/mixxx_bisect/runner/linux.py
+++ b/mixxx_bisect/runner/linux.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from mixxx_bisect.options import Options
+from mixxx_bisect.runner import SnapshotRunner
+from mixxx_bisect.utils.run import run
+
+import shutil
+
+class LinuxSnapshotRunner(SnapshotRunner):
+    def __init__(self, opts: Options):
+        self.mount_dir = opts.mount_dir
+        self.install_dir = opts.mount_dir / 'mixxx'
+        self.opts = opts
+    
+    @property
+    def download_path(self) -> Path:
+        return self.opts.downloads_dir / 'mixxx-current.tar.gz'
+
+    def setup_snapshot(self):
+        print('Extracting snapshot...')
+        shutil.unpack_archive(self.download_path, self.install_dir)
+
+    def run_snapshot(self):
+        print('Running snapshot...')
+        run([str(self.install_dir / 'bin' / 'mixxx')], opts=self.opts)
+    
+    def cleanup_snapshot(self):
+        print('Cleaning up snapshot...')
+        shutil.rmtree(self.install_dir)

--- a/mixxx_bisect/runner/macos.py
+++ b/mixxx_bisect/runner/macos.py
@@ -6,7 +6,7 @@ from mixxx_bisect.utils.run import run
 
 class MacOSSnapshotRunner(SnapshotRunner):
     def __init__(self, opts: Options):
-        self.mount_dir = opts.mount_dir
+        self.mount_dir = opts.installs_dir / 'mnt'
         self.opts = opts
 
     @property
@@ -23,6 +23,7 @@ class MacOSSnapshotRunner(SnapshotRunner):
 
     def _mount_snapshot(self):
         print('Mounting snapshot...')
+        self.mount_dir.mkdir(parents=True, exist_ok=True)
         self.cdr_path.unlink(missing_ok=True)
         run(['hdiutil', 'convert', str(self.download_path), '-format', 'UDTO', '-o', str(self.cdr_path)], opts=self.opts)
         run(['hdiutil', 'attach', str(self.cdr_path), '-mountpoint', str(self.mount_dir)], opts=self.opts)

--- a/mixxx_bisect/runner/macos.py
+++ b/mixxx_bisect/runner/macos.py
@@ -8,10 +8,14 @@ class MacOSSnapshotRunner(SnapshotRunner):
     def __init__(self, opts: Options):
         self.mount_dir = opts.mount_dir
         self.opts = opts
+
+    @property
+    def suffix(self) -> str:
+        return '.dmg'
     
     @property
     def download_path(self) -> Path:
-        return self.opts.downloads_dir / 'mixxx-current.dmg'
+        return self.opts.downloads_dir / f'mixxx-current{self.suffix}'
     
     @property
     def cdr_path(self) -> Path:

--- a/mixxx_bisect/runner/windows.py
+++ b/mixxx_bisect/runner/windows.py
@@ -13,8 +13,12 @@ class WindowsSnapshotRunner(SnapshotRunner):
         self.opts = opts
     
     @property
+    def suffix(self) -> str:
+        return '.msi'
+
+    @property
     def download_path(self) -> Path:
-        return self.opts.downloads_dir / 'mixxx-current.msi'
+        return self.opts.downloads_dir / f'mixxx-current{self.suffix}'
 
     def setup_snapshot(self):
         print('Extracting snapshot...')

--- a/mixxx_bisect/runner/windows.py
+++ b/mixxx_bisect/runner/windows.py
@@ -8,8 +8,7 @@ import shutil
 
 class WindowsSnapshotRunner(SnapshotRunner):
     def __init__(self, opts: Options):
-        self.mount_dir = opts.mount_dir
-        self.install_dir = opts.mount_dir / 'Mixxx'
+        self.install_dir = opts.installs_dir / 'Mixxx'
         self.opts = opts
     
     @property
@@ -26,7 +25,7 @@ class WindowsSnapshotRunner(SnapshotRunner):
             'msiexec',
             '/a', str(self.download_path),           # Install the msi
             '/q',                                    # Install quietly i.e. without GUI
-            f'TARGETDIR={self.opts.mount_dir}',                # Install to custom target dir
+            f'TARGETDIR={self.opts.installs_dir}',                # Install to custom target dir
             '/li', str(self.opts.log_dir / 'msi-install.log'), # Log installation to file
         ], opts=self.opts)
 
@@ -36,7 +35,7 @@ class WindowsSnapshotRunner(SnapshotRunner):
 
     def cleanup_snapshot(self):
         print('Cleaning up snapshot...')
-        for path in self.opts.mount_dir.iterdir():
+        for path in self.opts.installs_dir.iterdir():
             if path.is_file():
                 path.unlink()
             else:


### PR DESCRIPTION
### Fixes #9 

This finally adds proper Linux support via the static m1xxx builds. Additionally it updates the terminology to reflect the cross-platform nature of the tool (`~/.local/state/mixxx-bisect/installs` instead of `.../mnt`).